### PR TITLE
Convert 3 Growth-track chapters to v2 template

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -47,10 +47,10 @@ website:
           - content/realgdpacross.ipynb
       - section: "Growth & Long-Run Dynamics"
         contents:
-          - content/foundations_growth.ipynb
-          - content/cobb_d_prod.ipynb
+          - content/foundations_growth.qmd
+          - content/cobb_d_prod.qmd
           - content/solow_intro.qmd
-          - content/solow_transition.ipynb
+          - content/solow_transition.qmd
           - "content/solow_pop&_tech_growth.ipynb"
           - content/humancapital.ipynb
           - content/solow_model.ipynb

--- a/content/_archive/cobb_d_prod_v1.ipynb
+++ b/content/_archive/cobb_d_prod_v1.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "archive-provenance"
+    ]
+   },
+   "source": [
+    "> **Archived 2026-05-28.** The v1 Jupyter Book Cobb-Douglas Production notebook. Superseded by the Quarto v2 chapter [`content/cobb_d_prod.qmd`](../cobb_d_prod.qmd), which keeps the same Y = A\u00b7K\u1d45\u00b7L\u00b9\u207b\u1d45 model (diminishing MPK, constant returns to scale) but replaces the matplotlib+ipywidgets explorer with a live Observable JS production-function simulator. Kept verbatim for reference."
+   ]
+  },
+  {
    "cell_type": "raw",
    "metadata": {},
    "source": [

--- a/content/_archive/foundations_growth_v1.ipynb
+++ b/content/_archive/foundations_growth_v1.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "archive-provenance"
+    ]
+   },
+   "source": [
+    "> **Archived 2026-05-28.** The v1 Jupyter Book \"Levels vs. Growth Rates\" notebook. Superseded by the Quarto v2 chapter [`content/foundations_growth.qmd`](../foundations_growth.qmd), which keeps the same level-vs-growth-rate model but replaces the matplotlib+ipywidgets simulator with a live Observable JS simulator. Kept verbatim for reference."
+   ]
+  },
+  {
    "cell_type": "raw",
    "metadata": {},
    "source": [

--- a/content/_archive/solow_transition_v1.ipynb
+++ b/content/_archive/solow_transition_v1.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "archive-provenance"
+    ]
+   },
+   "source": [
+    "> **Archived 2026-05-28.** The v1 Jupyter Book \"Solow Transition with Constant L and A\" notebook. Superseded by the Quarto v2 chapter [`content/solow_transition.qmd`](../solow_transition.qmd), which keeps the same constant-L/A capital-accumulation model (k* = (sA/\u03b4)^(1/(1-\u03b1))) but replaces the matplotlib+ipywidgets transition plot with a live Observable JS convergence simulator. Kept verbatim for reference."
+   ]
+  },
+  {
    "cell_type": "raw",
    "metadata": {},
    "source": [

--- a/content/cobb_d_prod.qmd
+++ b/content/cobb_d_prod.qmd
@@ -1,0 +1,122 @@
+---
+title: "Cobb-Douglas Production"
+subtitle: "Turning capital and labor into output — with diminishing returns and constant returns to scale"
+---
+
+{{< include ../_includes/generated/cobb_d_prod-prereqs.md >}}
+
+::: {.im-tldr}
+**TL;DR** — $Y = A\,K^{\alpha}L^{1-\alpha}$ converts capital and labor into output. Add more of *one* input and you get diminishing returns; scale *both* by the same factor and output scales by exactly that factor (constant returns to scale). The exponent $\alpha$ is capital's share of income.
+:::
+
+## You'll be able to
+
+- Read the production function as a curve and explain why it flattens (diminishing marginal product of capital).
+- Distinguish the marginal product (MPK) from the average product (APK), and use $MPK = \alpha\cdot APK$.
+- State what constant returns to scale means and why this functional form guarantees it.
+
+## 🚀 Try it first
+
+::: {.im-sim-hero}
+::: {.im-sim-label}
+Move capital and watch the slope (MPK) shrink
+:::
+
+```{ojs}
+//| echo: false
+viewof Acd     = Inputs.range([0.5, 3.0], {value: 1.0, step: 0.1, label: "TFP A"})
+viewof Lcd     = Inputs.range([10, 300], {value: 100, step: 10, label: "labor L"})
+viewof alphacd = Inputs.range([0.05, 0.95], {value: 0.33, step: 0.01, label: "capital share α"})
+viewof Kcd     = Inputs.range([10, 300], {value: 100, step: 10, label: "capital K (the marked point)"})
+
+Ycd = (k) => Acd * Math.pow(k, alphacd) * Math.pow(Lcd, 1 - alphacd)
+Ypoint = Ycd(Kcd)
+MPK = alphacd * Ypoint / Kcd
+APK = Ypoint / Kcd
+
+curve = d3.range(1, 301, 2).map(k => ({k, Y: Ycd(k)}))
+tangent = [{k: Math.max(1, Kcd - 60), Y: Ypoint - MPK * 60}, {k: Kcd + 60, Y: Ypoint + MPK * 60}]
+
+Plot.plot({
+  marginLeft: 55,
+  x: {label: "capital K →", domain: [0, 300]},
+  y: {label: "output Y", grid: true},
+  marks: [
+    Plot.line(curve, {x: "k", y: "Y", stroke: "var(--im-accent)", strokeWidth: 2.5}),
+    Plot.line(tangent, {x: "k", y: "Y", stroke: "var(--im-sim)", strokeDasharray: "4 4"}),
+    Plot.dot([{k: Kcd, Y: Ypoint}], {x: "k", y: "Y", fill: "var(--im-danger)", r: 5}),
+    Plot.text([{k: Kcd, Y: Ypoint}], {text: d => `MPK = ${MPK.toFixed(2)}`, dy: -14, fill: "var(--im-sim)"})
+  ]
+})
+```
+
+```{ojs}
+//| echo: false
+md`At **K = ${Kcd}, L = ${Lcd}**: output **Y = ${Ypoint.toFixed(0)}**, marginal product **MPK = ${MPK.toFixed(2)}**, average product **APK = ${APK.toFixed(2)}**. Notice **MPK = α · APK** — and the dashed tangent gets flatter as you slide K right.`
+```
+:::
+
+## Core intuition
+
+Output comes from combining capital and labor. Hold labor fixed and pour in more capital: each new machine adds output, but *less* than the one before it, because there are only so many workers to operate them. That's [diminishing returns]{.im-glossary-term} — the curve rises but flattens, and its slope (the [marginal product of capital]{.im-glossary-term}) falls.
+
+Now scale *both* inputs together — double the workers *and* the machines — and output exactly doubles. That's [constant returns to scale]{.im-glossary-term}, and it's baked into this form because the exponents $\alpha$ and $1-\alpha$ sum to one. The same $\alpha$ that controls the curvature also equals capital's share of national income.
+
+::: {.im-math-toggle}
+<details>
+<summary>Show the math</summary>
+
+The marginal product of capital is the derivative holding $L$ fixed:
+$$MPK = \frac{\partial Y}{\partial K} = \alpha A K^{\alpha-1} L^{1-\alpha} = \alpha\,\frac{Y}{K} = \alpha\cdot APK.$$
+Since $\alpha < 1$, $MPK$ falls as $K$ rises — diminishing returns.
+
+For constant returns to scale, scale both inputs by $\lambda$:
+$$A(\lambda K)^{\alpha}(\lambda L)^{1-\alpha} = \lambda^{\alpha+1-\alpha}\,A K^{\alpha}L^{1-\alpha} = \lambda Y.$$
+Output scales by exactly $\lambda$ because the exponents sum to one.
+
+</details>
+:::
+
+## What the simulator showed
+
+Sliding **K** to the right raised output but the dashed tangent line — the slope, i.e. MPK — kept flattening: more capital, less bang per unit. Raising **A** or **L** shifted the whole curve up. And at every point the readout confirmed $MPK = \alpha\cdot APK$. The curvature is governed entirely by $\alpha$: push it toward 1 and capital barely diminishes; push it toward 0 and it diminishes fast.
+
+## Common confusions
+
+::: {.im-confusion}
+**"Diminishing returns means output falls."** No — output keeps *rising* with more capital; it just rises by smaller and smaller amounts. The level increases; the *marginal* product decreases.
+:::
+
+::: {.im-confusion}
+**"Constant returns to scale contradicts diminishing returns."** They're about different experiments. Diminishing returns = adding *one* input. Constant returns to scale = adding *all* inputs proportionally. Both hold here at once.
+:::
+
+## Self-check
+
+<div class="im-mcq">
+<div class="im-q-label">Q1 · concept</div>
+
+With $Y = A K^{\alpha} L^{1-\alpha}$ and $\alpha = 0.33$, you double **only** capital $K$. Output...
+
+<details><summary>a) doubles</summary>
+No — doubling only one input gives less than double, because of diminishing returns. Output rises by a factor of $2^{0.33} \approx 1.26$.
+</details>
+<details><summary>b) rises by about 26%</summary>
+✅ Correct. $Y$ scales by $2^{\alpha} = 2^{0.33} \approx 1.26$ — a 26% gain, not 100%.
+</details>
+<details><summary>c) more than doubles</summary>
+No — a single factor with exponent below 1 gives diminishing, not increasing, returns.
+</details>
+</div>
+
+<div class="im-mcq">
+<div class="im-q-label">Q2 · simulator challenge</div>
+
+Set **A = 1, L = 100, α = 0.33, K = 100**. What is output Y (to the nearest whole number)?
+
+<details><summary>Reveal answer</summary>
+$Y = 1\cdot 100^{0.33}\cdot 100^{0.67} = 100^{1} = 100$. The readout should show **Y ≈ 100** (and APK ≈ 1, MPK ≈ 0.33).
+</details>
+</div>
+
+{{< include ../_includes/generated/cobb_d_prod-related.md >}}

--- a/content/foundations_growth.qmd
+++ b/content/foundations_growth.qmd
@@ -1,0 +1,119 @@
+---
+title: "Levels vs. Growth Rates"
+subtitle: "How rich you are and how fast you're getting richer are two different things"
+---
+
+{{< include ../_includes/generated/foundations_growth-prereqs.md >}}
+
+::: {.im-tldr}
+**TL;DR** — The *level* of GDP per capita (how rich a country is now) and its *growth rate* (how fast it's getting richer) are distinct, and often move in opposite directions across countries. A poor country can grow fast; a rich country can crawl.
+:::
+
+## You'll be able to
+
+- Separate the *level* of a variable from its *growth rate* — and explain why a high level doesn't imply fast growth.
+- Read a time path and identify which of two economies is richer vs. which is catching up.
+- Connect this distinction to the convergence pattern you'll see in later chapters.
+
+## 🚀 Try it first
+
+::: {.im-sim-hero}
+::: {.im-sim-label}
+Drag the sliders — the two paths update live
+:::
+
+```{ojs}
+//| echo: false
+viewof levelA = Inputs.range([1, 10], {value: 2.0, step: 0.5, label: "start level — A"})
+viewof gA     = Inputs.range([-0.05, 0.5], {value: 0.20, step: 0.01, label: "growth rate — A"})
+viewof levelB = Inputs.range([1, 10], {value: 6.0, step: 0.5, label: "start level — B"})
+viewof gB     = Inputs.range([-0.05, 0.5], {value: 0.00, step: 0.01, label: "growth rate — B"})
+viewof Tyears = Inputs.range([1, 30], {value: 12, step: 1, label: "years"})
+
+series = {
+  const rows = [];
+  for (let t = 0; t <= Tyears; t++) {
+    rows.push({t, value: levelA * Math.pow(1 + gA, t), who: "A"});
+    rows.push({t, value: levelB * Math.pow(1 + gB, t), who: "B"});
+  }
+  return rows;
+}
+
+Plot.plot({
+  marginLeft: 50, marginRight: 60,
+  x: {label: "year →"},
+  y: {label: "level of the variable", grid: true},
+  marks: [
+    Plot.line(series.filter(d => d.who === "A"), {x: "t", y: "value", stroke: "var(--im-accent)", strokeWidth: 2.5}),
+    Plot.line(series.filter(d => d.who === "B"), {x: "t", y: "value", stroke: "var(--im-sim)", strokeWidth: 2.5, strokeDasharray: "5 4"}),
+    Plot.text([{t: Tyears, value: levelA * Math.pow(1 + gA, Tyears)}], {text: d => `A: ${d.value.toFixed(1)}`, dx: 8, fill: "var(--im-accent)"}),
+    Plot.text([{t: Tyears, value: levelB * Math.pow(1 + gB, Tyears)}], {text: d => `B: ${d.value.toFixed(1)}`, dx: 8, fill: "var(--im-sim)"})
+  ]
+})
+```
+
+The solid blue line is economy **A**; the dashed green line is economy **B**. Set A to a low level with a high growth rate and B to a high level with zero growth — then watch A overtake B.
+:::
+
+## Core intuition
+
+Think of a child and an adult. The child is *short* (low level) but *growing fast* (high growth rate). The adult is *tall* (high level) but no longer growing (zero growth rate). Snap a photo today and the adult is taller; wait fifteen years and the child may tower over them.
+
+Countries work the same way. The level tells you how rich a place is *right now*; the growth rate tells you how the gap is *changing*. A rich country growing at 1.8% a year and a poor country growing at 8% are on a collision course — even though the rich one is far ahead today. That gap-closing is exactly the [convergence]{.im-glossary-term} story growth models try to explain.
+
+::: {.im-math-toggle}
+<details>
+<summary>Show the math</summary>
+
+A variable growing at a constant rate $g$ from a starting level $x_0$ follows
+$$x_t = x_0\,(1+g)^t.$$
+Two economies $A$ and $B$ cross when $x_{A,0}(1+g_A)^t = x_{B,0}(1+g_B)^t$. Solving for the crossover year,
+$$t^{*} = \frac{\ln(x_{B,0}/x_{A,0})}{\ln\!\big((1+g_A)/(1+g_B)\big)}.$$
+As long as $g_A > g_B$, the lower-level economy *always* catches up eventually — the only question is when.
+
+</details>
+:::
+
+## What the simulator showed
+
+With A starting low but growing fast and B starting high but flat, the two lines crossed: A's growth rate beat B's head start. Raising B's growth rate to match A's pushes the crossover off to infinity — they stay parallel and the initial gap never closes. **Levels set where you start; growth rates decide who wins the race.**
+
+## Common confusions
+
+::: {.im-confusion}
+**"A richer country must be growing faster."** No — level and growth rate are independent. The richest economies usually grow *slowly*; the fastest growers are often catching up from a low base.
+:::
+
+::: {.im-confusion}
+**"A negative growth rate means a low level."** No — an economy can be at a high level and still shrink (negative growth), or sit at a low level and boom. The two axes are separate.
+:::
+
+## Self-check
+
+<div class="im-mcq">
+<div class="im-q-label">Q1 · concept</div>
+
+Country X has GDP per capita of \$40,000 growing at 1%. Country Y has \$5,000 growing at 7%. Which is true?
+
+<details><summary>a) X will always be richer — it has the higher level</summary>
+No — Y's far higher growth rate means it closes the gap and eventually overtakes X.
+</details>
+<details><summary>b) Y is catching up and will overtake X given enough time</summary>
+✅ Correct. A higher growth rate compounds; the level head-start is finite, so Y eventually passes X.
+</details>
+<details><summary>c) They grow at the same speed since growth is just level times rate</summary>
+No — growth *rate* is independent of the level. Y's 7% beats X's 1% regardless of who is richer now.
+</details>
+</div>
+
+<div class="im-mcq">
+<div class="im-q-label">Q2 · simulator challenge</div>
+
+Set **A: level = 2, g = 0.20** and **B: level = 6, g = 0.00**. Roughly what year does A overtake B?
+
+<details><summary>Reveal answer</summary>
+Solve $2(1.2)^t = 6 \Rightarrow t = \ln(3)/\ln(1.2) \approx 6.0$. A passes B around **year 6** — confirm it on the chart.
+</details>
+</div>
+
+{{< include ../_includes/generated/foundations_growth-related.md >}}

--- a/content/solow_transition.qmd
+++ b/content/solow_transition.qmd
@@ -1,0 +1,129 @@
+---
+title: "Solow Transition Dynamics"
+subtitle: "How an economy actually travels to its steady state — fast at first, then slower"
+---
+
+{{< include ../_includes/generated/solow_transition-prereqs.md >}}
+
+::: {.im-tldr}
+**TL;DR** — Below its steady state, an economy's capital grows because investment outruns depreciation — but the gap closes at a *decreasing* rate, so growth is rapid when you're poor and crawls as you approach $k^{*}$. Start *above* $k^{*}$ and capital shrinks back down. Either way, you converge.
+:::
+
+## You'll be able to
+
+- Trace the path of capital and output over time toward the steady state.
+- Explain why convergence is fast far from $k^{*}$ and slow near it.
+- Predict what happens when an economy starts *above* its steady state.
+
+## 🚀 Try it first
+
+::: {.im-sim-hero}
+::: {.im-sim-label}
+Change the starting capital and watch how fast it converges
+:::
+
+```{ojs}
+//| echo: false
+viewof Atr     = Inputs.range([0.5, 2.0], {value: 1.0, step: 0.1, label: "TFP A"})
+viewof str     = Inputs.range([0.05, 0.5], {value: 0.20, step: 0.01, label: "savings rate s"})
+viewof deltatr = Inputs.range([0.01, 0.2], {value: 0.05, step: 0.01, label: "depreciation δ"})
+viewof alphatr = Inputs.range([0.2, 0.5], {value: 0.33, step: 0.01, label: "capital share α"})
+viewof k0tr    = Inputs.range([0.1, 12], {value: 0.5, step: 0.1, label: "initial capital k₀"})
+viewof Ttr     = Inputs.range([20, 100], {value: 60, step: 5, label: "time horizon"})
+
+kstar = Math.pow(str * Atr / deltatr, 1 / (1 - alphatr))
+ystar = Atr * Math.pow(kstar, alphatr)
+
+trpath = {
+  const T = Ttr, rows = [];
+  let k = k0tr;
+  for (let t = 0; t < T; t++) {
+    const y = Atr * Math.pow(k, alphatr);
+    rows.push({t, k, y});
+    k = k + str * y - deltatr * k;
+  }
+  return rows;
+}
+
+Plot.plot({
+  marginLeft: 50,
+  x: {label: "time →"},
+  y: {label: "level", grid: true},
+  marks: [
+    Plot.ruleY([kstar], {stroke: "var(--im-accent)", strokeDasharray: "3 3", opacity: 0.5}),
+    Plot.ruleY([ystar], {stroke: "var(--im-sim)", strokeDasharray: "3 3", opacity: 0.5}),
+    Plot.line(trpath, {x: "t", y: "k", stroke: "var(--im-accent)", strokeWidth: 2.5}),
+    Plot.line(trpath, {x: "t", y: "y", stroke: "var(--im-sim)", strokeWidth: 2.5}),
+    Plot.text([{t: Ttr * 0.5, y: kstar}], {text: d => `k* = ${kstar.toFixed(2)}`, dy: -8, fill: "var(--im-accent)"}),
+    Plot.text([{t: Ttr * 0.5, y: ystar}], {text: d => `y* = ${ystar.toFixed(2)}`, dy: -8, fill: "var(--im-sim)"})
+  ]
+})
+```
+
+The blue line is capital per worker, green is output per worker, and the dashed lines are their steady-state targets. Try a tiny $k_0$ (rapid catch-up) versus a $k_0$ *above* $k^{*}$ (the economy shrinks down).
+:::
+
+## Core intuition
+
+Each period the economy invests a slice $s$ of its output and loses a slice $\delta$ of its capital to wear and tear. When capital is low, output is high *relative to* the capital stock (high average product), so investment easily beats depreciation and capital piles up fast. As capital grows, [diminishing returns]{.im-glossary-term} shrink the extra output each unit brings, investment and depreciation drift toward each other, and growth peters out.
+
+The resting point is where they exactly balance: $s A k^{\alpha} = \delta k$. That's the [steady state]{.im-glossary-term} $k^{*}$. Crucially, the *further* you are below it, the faster you move toward it — which is the engine behind the [convergence]{.im-glossary-term} prediction that poor economies should grow faster than rich ones.
+
+::: {.im-math-toggle}
+<details>
+<summary>Show the math</summary>
+
+With constant $A$ and $L$, capital evolves as
+$$\dot{k} = s A k^{\alpha} - \delta k.$$
+Setting $\dot k = 0$ gives the steady state
+$$k^{*} = \left(\frac{sA}{\delta}\right)^{\frac{1}{1-\alpha}}, \qquad y^{*} = A (k^{*})^{\alpha}.$$
+The growth rate of capital is
+$$\frac{\dot k}{k} = sA k^{\alpha - 1} - \delta,$$
+which *falls* as $k$ rises (since $\alpha - 1 < 0$) — convergence slows as you approach $k^{*}$, and reverses sign if you start above it.
+
+</details>
+:::
+
+## What the simulator showed
+
+Starting from a tiny $k_0$, both lines shot up steeply, then bent over and leveled off at the dashed targets — fast growth early, slow growth late. Starting from a $k_0$ *above* $k^{*}$, the lines came *down* to the same targets: too much capital depreciates faster than it's replaced. The steady state is an attractor from both directions, and the speed of approach depends only on how far away you are.
+
+## Common confusions
+
+::: {.im-confusion}
+**"An economy above its steady state keeps growing."** No — if $k_0 > k^{*}$, depreciation outweighs investment and capital *falls* back to $k^{*}$. Steady state is reached from above as well as below.
+:::
+
+::: {.im-confusion}
+**"Convergence speed is constant."** No — growth is fastest when farthest below $k^{*}$ and slows continuously as you approach. The path is curved, not a straight ramp.
+:::
+
+## Self-check
+
+<div class="im-mcq">
+<div class="im-q-label">Q1 · concept</div>
+
+Two economies have identical $s$, $\delta$, $\alpha$, $A$ but different starting capital: one far below $k^{*}$, one just below it. Which grows faster initially?
+
+<details><summary>a) The one far below k*</summary>
+✅ Correct. The further below $k^{*}$, the larger the gap between investment and depreciation, so the faster capital grows. This is the convergence mechanism.
+</details>
+<details><summary>b) The one just below k*</summary>
+No — near $k^{*}$ investment and depreciation nearly balance, so growth is slow.
+</details>
+<details><summary>c) They grow at the same rate since the parameters match</summary>
+No — growth rate depends on the *distance* from $k^{*}$, not just the parameters.
+</details>
+</div>
+
+<div class="im-mcq">
+<div class="im-q-label">Q2 · simulator challenge</div>
+
+Set **A = 1, s = 0.20, δ = 0.05, α = 0.33**. What is the steady-state capital $k^{*}$?
+
+<details><summary>Reveal answer</summary>
+$k^{*} = (sA/\delta)^{1/(1-\alpha)} = (0.20/0.05)^{1/0.67} = 4^{1.49} \approx 7.9$. The dashed blue line should sit near **k* ≈ 7.9**.
+</details>
+</div>
+
+{{< include ../_includes/generated/solow_transition-related.md >}}


### PR DESCRIPTION
## Summary
Continues the v2 rollout by converting three Growth-track chapters from static notebooks to the interactive v2 template. These scaffold the existing Solow showcase — its two prerequisites plus its direct follow-on.

- **Levels vs. Growth Rates** (`foundations_growth`) — two compounding paths; see a low-level/high-growth economy overtake a high-level/flat one.
- **Cobb-Douglas Production** (`cobb_d_prod`) — production-function explorer with a live tangent line showing MPK shrink (diminishing returns) and `MPK = α·APK`.
- **Solow Transition Dynamics** (`solow_transition`) — capital/output convergence to steady state; fast far below k*, slow near it, and falling when started above.

Each chapter gets the full 10-section template (prereq chips → TL;DR → goals → OJS sim-hero → intuition → collapsible math → "what the sim showed" → confusions → MCQs → related cards).

## Models preserved
ipywidgets simulators reimplemented in Observable JS; the economic models/equations are unchanged. Originals archived to `content/_archive/<name>_v1.ipynb` with dated provenance notes (never deleted). Sidebar updated to the `.qmd` versions.

## Verified in browser
- [x] All three render fully (sim SVG, sliders, MCQs, related-cards footer — nothing swallowed)
- [x] Cobb-Douglas: 4 sliders + tangent/MPK readout
- [x] Solow Transition: 6 sliders + dual-line convergence plot, 2 related cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)