### PR TITLE
Site cleanup: render fix, academic landing, de-vibecode, +3 chapters

### DIFF
--- a/_includes/generated/convergence_hypo-prereqs.md
+++ b/_includes/generated/convergence_hypo-prereqs.md
@@ -1,0 +1,5 @@
+```{=html}
+<div class="im-prereq-chips">
+<a class="im-prereq-chip" href="solow_transition.html" title="Below steady state, capital grows faster than replacement, so the economy converges upward along a predictable path.">requires: Solow Transition Dynamics</a>
+</div>
+```

--- a/_includes/generated/convergence_hypo-related.md
+++ b/_includes/generated/convergence_hypo-related.md
@@ -1,0 +1,6 @@
+```{=html}
+<div class="im-related-cards">
+<a class="im-related-card" href="solow_transition.html"><div class="im-role">prereq</div><strong>Solow Transition Dynamics</strong></a>
+<a class="im-related-card" href="solow_intro.html"><div class="im-role">sibling</div><strong>The Solow Growth Model</strong></a>
+</div>
+```

--- a/_includes/generated/humancapital-prereqs.md
+++ b/_includes/generated/humancapital-prereqs.md
@@ -1,0 +1,5 @@
+```{=html}
+<div class="im-prereq-chips">
+<a class="im-prereq-chip" href="solow_intro.html" title="Raise the savings rate and you get a richer country, not a faster-growing one — long-run growth is set by technology.">requires: The Solow Growth Model</a>
+</div>
+```

--- a/_includes/generated/humancapital-related.md
+++ b/_includes/generated/humancapital-related.md
@@ -2,6 +2,5 @@
 <div class="im-related-cards">
 <a class="im-related-card" href="solow_intro.html"><div class="im-role">prereq</div><strong>The Solow Growth Model</strong></a>
 <a class="im-related-card" href="cobb_d_prod.html"><div class="im-role">sibling</div><strong>Cobb-Douglas Production</strong></a>
-<a class="im-related-card" href="convergence_hypo.html"><div class="im-role">next</div><strong>The Convergence Hypothesis</strong></a>
 </div>
 ```

--- a/_includes/generated/solow_pop&_tech_growth-prereqs.md
+++ b/_includes/generated/solow_pop&_tech_growth-prereqs.md
@@ -1,0 +1,5 @@
+```{=html}
+<div class="im-prereq-chips">
+<a class="im-prereq-chip" href="solow_intro.html" title="Raise the savings rate and you get a richer country, not a faster-growing one — long-run growth is set by technology.">requires: The Solow Growth Model</a>
+</div>
+```

--- a/_includes/generated/solow_pop&_tech_growth-related.md
+++ b/_includes/generated/solow_pop&_tech_growth-related.md
@@ -2,6 +2,5 @@
 <div class="im-related-cards">
 <a class="im-related-card" href="solow_intro.html"><div class="im-role">prereq</div><strong>The Solow Growth Model</strong></a>
 <a class="im-related-card" href="cobb_d_prod.html"><div class="im-role">sibling</div><strong>Cobb-Douglas Production</strong></a>
-<a class="im-related-card" href="convergence_hypo.html"><div class="im-role">next</div><strong>The Convergence Hypothesis</strong></a>
 </div>
 ```

--- a/_includes/prereqs.yml
+++ b/_includes/prereqs.yml
@@ -19,6 +19,21 @@ solow_transition:
   title: "Solow Transition Dynamics"
   tldr: "Below steady state, capital grows faster than replacement, so the economy converges upward along a predictable path."
   prereqs: [solow_intro]
+solow_pop&_tech_growth:
+  track: growth
+  title: "Population & Technology Growth"
+  tldr: "Per-effective-worker variables settle at a steady state; living standards then grow only at the rate of technology, while faster population growth dilutes capital."
+  prereqs: [solow_intro]
+humancapital:
+  track: growth
+  title: "Human Capital"
+  tldr: "A second accumulable factor alongside physical capital; raising human-capital investment lifts the steady-state level of income."
+  prereqs: [solow_intro]
+convergence_hypo:
+  track: growth
+  title: "The Convergence Hypothesis"
+  tldr: "Economies sharing the same parameters converge to the same steady state (absolute); with different parameters they converge only to their own (conditional)."
+  prereqs: [solow_transition]
 two_period_consumption:
   track: intertemporal
   title: "Two-Period Consumption"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -51,14 +51,14 @@ website:
           - content/cobb_d_prod.qmd
           - content/solow_intro.qmd
           - content/solow_transition.qmd
-          - "content/solow_pop&_tech_growth.ipynb"
-          - content/humancapital.ipynb
+          - "content/solow_pop&_tech_growth.qmd"
+          - content/humancapital.qmd
+          - content/convergence_hypo.qmd
           - content/solow_model.ipynb
           - content/romer_model.ipynb
           - content/scale_effects.ipynb
           - content/hybrid_model.ipynb
           - content/growth_acc.ipynb
-          - content/convergence_hypo.ipynb
           - content/slowinggrowth.ipynb
           - content/robots.ipynb
       - section: "Intertemporal Choice & Labor"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -91,6 +91,9 @@ format:
           <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=STIX+Two+Math&display=swap" rel="stylesheet">
     include-after-body:
       - theme/glossary-tooltips.js
+      - theme/widget-fallback.js
 
 execute:
   freeze: auto
+  echo: false
+  warning: false

--- a/content/_archive/convergence_hypo_v1.ipynb
+++ b/content/_archive/convergence_hypo_v1.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "archive-provenance"
+    ]
+   },
+   "source": [
+    "> **Archived original.** Pre-conversion ipywidgets notebook for *The Convergence Hypothesis*, preserved for provenance. Live chapter is now content/convergence_hypo.qmd (interactive Observable JS). Archived 2026-05-28."
+   ]
+  },
+  {
    "cell_type": "raw",
    "metadata": {},
    "source": [

--- a/content/_archive/humancapital_v1.ipynb
+++ b/content/_archive/humancapital_v1.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "archive-provenance"
+    ]
+   },
+   "source": [
+    "> **Archived original.** Pre-conversion ipywidgets notebook for *Human Capital*, preserved for provenance. Live chapter is now content/humancapital.qmd (interactive Observable JS). Archived 2026-05-28."
+   ]
+  },
+  {
    "cell_type": "raw",
    "metadata": {},
    "source": [

--- a/content/_archive/solow_pop&_tech_growth_v1.ipynb
+++ b/content/_archive/solow_pop&_tech_growth_v1.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "archive-provenance"
+    ]
+   },
+   "source": [
+    "> **Archived original.** This is the pre-conversion ipywidgets notebook for *Population & Technology Growth*, preserved for provenance. The live chapter is now content/solow_pop&_tech_growth.qmd (interactive Observable JS). Archived 2026-05-28."
+   ]
+  },
+  {
    "cell_type": "raw",
    "metadata": {},
    "source": [

--- a/content/adassim.qmd
+++ b/content/adassim.qmd
@@ -15,7 +15,7 @@ subtitle: "How monetary policy stabilizes output and inflation — and when it f
 - Explain why φπ > 1 (the Taylor principle) is necessary for the inflation path to converge.
 - Read a time-series chart of the dynamic AD-AS model and identify convergent versus oscillatory/divergent paths.
 
-## 🚀 Try it first
+## Explore the model
 
 ::: {.im-sim-hero}
 ::: {.im-sim-label}
@@ -129,7 +129,7 @@ What does the Taylor principle require, and why does it matter for stability?
 No — a positive response is necessary but not sufficient. If φπ < 1 the central bank raises rates by less than the inflation gap, leaving the real interest rate adjustment too small to close the gap. Inflation deviations feed on themselves.
 </details>
 <details><summary>b) φπ > 1 — the rate response must exceed the inflation gap one-for-one</summary>
-✅ Correct. With φπ > 1 each unit of excess inflation triggers a more-than-proportionate rate hike, which cuts output via the IS curve, which reduces inflation via the Phillips curve — a self-correcting loop. Below 1, the loop amplifies rather than dampens.
+**Correct**. With φπ > 1 each unit of excess inflation triggers a more-than-proportionate rate hike, which cuts output via the IS curve, which reduces inflation via the Phillips curve — a self-correcting loop. Below 1, the loop amplifies rather than dampens.
 </details>
 <details><summary>c) φπ = 1 exactly — the rate response must match inflation one-for-one</summary>
 No — at φπ = 1 the economy is on the boundary: the feedback coefficient equals 1 in absolute value (with λα = 1) and the inflation gap neither grows nor shrinks. You need strict inequality φπ > 1 for convergence.

--- a/content/cobb_d_prod.qmd
+++ b/content/cobb_d_prod.qmd
@@ -15,7 +15,7 @@ subtitle: "Turning capital and labor into output — with diminishing returns an
 - Distinguish the marginal product (MPK) from the average product (APK), and use $MPK = \alpha\cdot APK$.
 - State what constant returns to scale means and why this functional form guarantees it.
 
-## 🚀 Try it first
+## Explore the model
 
 ::: {.im-sim-hero}
 ::: {.im-sim-label}
@@ -102,7 +102,7 @@ With $Y = A K^{\alpha} L^{1-\alpha}$ and $\alpha = 0.33$, you double **only** ca
 No — doubling only one input gives less than double, because of diminishing returns. Output rises by a factor of $2^{0.33} \approx 1.26$.
 </details>
 <details><summary>b) rises by about 26%</summary>
-✅ Correct. $Y$ scales by $2^{\alpha} = 2^{0.33} \approx 1.26$ — a 26% gain, not 100%.
+**Correct**. $Y$ scales by $2^{\alpha} = 2^{0.33} \approx 1.26$ — a 26% gain, not 100%.
 </details>
 <details><summary>c) more than doubles</summary>
 No — a single factor with exponent below 1 gives diminishing, not increasing, returns.

--- a/content/convergence_hypo.qmd
+++ b/content/convergence_hypo.qmd
@@ -1,0 +1,162 @@
+---
+title: "The Convergence Hypothesis"
+subtitle: "When do poor countries catch up to rich ones — and when do they not?"
+---
+
+{{< include ../_includes/generated/convergence_hypo-prereqs.md >}}
+
+::: {.im-tldr}
+**TL;DR** — The Solow model says an economy grows faster the further it sits *below* its own steady state. If two countries share the same $s$, $\delta$, $n$, $\alpha$, the poorer one grows faster and *catches up* (**absolute convergence**). If their parameters differ, each races toward its *own* steady state — they converge, but not to each other (**conditional convergence**).
+:::
+
+## You'll be able to
+
+- Distinguish **absolute** convergence (same parameters → same $k^{*}$ → the gap closes) from **conditional** convergence (different parameters → different $k^{*}$ → the gap need not close).
+- Explain the empirical signature of convergence: a *negative* relationship between initial income and subsequent growth, holding steady-state determinants constant.
+- Predict, for two economies, whether and how fast the income gap between them will shrink.
+
+## 🚀 Try it first
+
+::: {.im-sim-hero}
+::: {.im-sim-label}
+Two economies, one poor and one rich — watch whether the gap between them closes
+:::
+
+```{ojs}
+//| echo: false
+viewof sCv      = Inputs.range([0.05, 0.5], {value: 0.20, step: 0.01, label: "savings rate s (Country A)"})
+viewof deltaCv  = Inputs.range([0.01, 0.2], {value: 0.05, step: 0.01, label: "depreciation δ"})
+viewof nCv      = Inputs.range([0.0, 0.05], {value: 0.0, step: 0.005, label: "population growth n"})
+viewof alphaCv  = Inputs.range([0.2, 0.5], {value: 0.33, step: 0.01, label: "capital share α"})
+viewof k0aCv    = Inputs.range([0.1, 4], {value: 0.5, step: 0.1, label: "initial capital k₀ — Country A (poor)"})
+viewof k0bCv    = Inputs.range([4, 16], {value: 9, step: 0.1, label: "initial capital k₀ — Country B (rich)"})
+viewof condCv   = Inputs.toggle({label: "Conditional convergence (give B a higher savings rate)", value: false})
+viewof sBCv     = Inputs.range([0.05, 0.5], {value: 0.35, step: 0.01, label: "savings rate s (Country B, only used if toggled)"})
+viewof TCv      = Inputs.range([20, 150], {value: 80, step: 5, label: "time horizon"})
+
+sB_Cv = condCv ? sBCv : sCv
+
+kstarA_Cv = Math.pow(sCv / (deltaCv + nCv), 1 / (1 - alphaCv))
+kstarB_Cv = Math.pow(sB_Cv / (deltaCv + nCv), 1 / (1 - alphaCv))
+ystarA_Cv = Math.pow(kstarA_Cv, alphaCv)
+ystarB_Cv = Math.pow(kstarB_Cv, alphaCv)
+
+simCv = {
+  const T = TCv, A = [], B = [];
+  let kA = k0aCv, kB = k0bCv;
+  for (let t = 0; t < T; t++) {
+    const yA = Math.pow(kA, alphaCv);
+    const yB = Math.pow(kB, alphaCv);
+    A.push({t, k: kA, y: yA, country: "A (poor)"});
+    B.push({t, k: kB, y: yB, country: "B (rich)"});
+    kA = kA + sCv  * yA - (deltaCv + nCv) * kA;
+    kB = kB + sB_Cv * yB - (deltaCv + nCv) * kB;
+  }
+  return {A, B};
+}
+
+Plot.plot({
+  marginLeft: 50,
+  x: {label: "time →"},
+  y: {label: "output per worker  y", grid: true, domain: [0, Math.max(ystarA_Cv, ystarB_Cv) * 1.15]},
+  marks: [
+    Plot.ruleY([ystarA_Cv], {stroke: "var(--im-accent)", strokeDasharray: "3 3", opacity: 0.5}),
+    Plot.ruleY([ystarB_Cv], {stroke: "var(--im-sim)",    strokeDasharray: "3 3", opacity: 0.5}),
+    Plot.line(simCv.A, {x: "t", y: "y", stroke: "var(--im-accent)", strokeWidth: 2.5}),
+    Plot.line(simCv.B, {x: "t", y: "y", stroke: "var(--im-sim)",    strokeWidth: 2.5}),
+    Plot.text([{t: TCv * 0.5, y: ystarA_Cv}], {text: d => `y*₍A₎ = ${ystarA_Cv.toFixed(2)}`, dy: 10, fill: "var(--im-accent)"}),
+    Plot.text([{t: TCv * 0.5, y: ystarB_Cv}], {text: d => `y*₍B₎ = ${ystarB_Cv.toFixed(2)}`, dy: -8, fill: "var(--im-sim)"})
+  ]
+})
+```
+
+```{ojs}
+//| echo: false
+growthCv = {
+  // current (last-period) growth rate of y for each country
+  const A = simCv.A, B = simCv.B, last = A.length - 1;
+  const gA = Math.log(A[last].y / A[last - 1].y);
+  const gB = Math.log(B[last].y / B[last - 1].y);
+  // early growth (first 5 years), where the gap is widest
+  const eA = Math.log(A[Math.min(5, last)].y / A[0].y) / Math.min(5, last);
+  const eB = Math.log(B[Math.min(5, last)].y / B[0].y) / Math.min(5, last);
+  return {gA, gB, eA, eB};
+}
+
+md`**Country A** (poor) starts at $y_0 = ${simCv.A[0].y.toFixed(2)}$ and heads for $y^{*} = ${ystarA_Cv.toFixed(2)}$.
+**Country B** (rich) starts at $y_0 = ${simCv.B[0].y.toFixed(2)}$ and heads for $y^{*} = ${ystarB_Cv.toFixed(2)}$.
+
+Early-period growth: **A ≈ ${(growthCv.eA * 100).toFixed(2)}%/yr**, **B ≈ ${(growthCv.eB * 100).toFixed(2)}%/yr** — ${growthCv.eA > growthCv.eB ? "the poorer country grows faster, so the gap is closing." : "the richer country grows at least as fast — no catch-up."} ${condCv ? "Because B saves more, the two aim at **different** steady states (conditional convergence)." : "Both share the same parameters, so they aim at the **same** steady state (absolute convergence) — A catches up to B."}`
+```
+:::
+
+## Core intuition
+
+The whole convergence story rides on [diminishing returns]{.im-glossary-term}. When a country has little capital per worker, each new machine produces a lot of extra output, so investment $s y$ easily beats the replacement cost $(\delta + n)k$ and capital piles up fast. As capital accumulates, the marginal product shrinks, investment and break-even drift together, and growth slows. The resting point — where $s y = (\delta+n)k$ — is the [steady state]{.im-glossary-term} $k^{*}$.
+
+The key consequence: an economy's growth rate depends on its *distance below its own steady state*. This is the engine of [convergence]{.im-glossary-term}. But "its own steady state" is the crucial qualifier:
+
+- **Absolute convergence.** If two economies share $s$, $\delta$, $n$, $\alpha$, they share the *same* $k^{*}$. The poorer one starts further below it, grows faster, and the income gap *closes*. Everyone ends equally rich.
+- **Conditional convergence.** If parameters differ, each economy converges to its *own* $k^{*}$. A poor country with a low saving rate may grow slowly because it is already near its (low) steady state — it converges, but the gap to a rich, high-saving country need not shrink at all.
+
+The empirical fingerprint of convergence is therefore a *negative* relationship between a country's initial income $\ln y_0$ and its later growth rate — but only **holding the determinants of the steady state constant**. Run that regression on raw world data and the relationship is roughly flat (absolute convergence fails); control for $s$, $n$, schooling, institutions, and a clear negative slope appears (conditional convergence holds).
+
+::: {.im-math-toggle}
+<details>
+<summary>Show the math</summary>
+
+Per-worker law of motion (with population growth $n$, technology $A=1$):
+$$k_{t+1} = k_t + s\,k_t^{\alpha} - (\delta + n)\,k_t, \qquad y = k^{\alpha}.$$
+Setting the change to zero gives the steady state
+$$k^{*} = \left(\frac{s}{\delta+n}\right)^{\frac{1}{1-\alpha}}, \qquad y^{*} = (k^{*})^{\alpha}.$$
+
+Linearizing around the steady state, the growth rate of output is approximately proportional to the **log gap** to its own target:
+$$g \;\approx\; \lambda\,\bigl(\ln y^{*} - \ln y\bigr), \qquad \lambda = (1-\alpha)(\delta+n).$$
+So $\lambda$ is the **speed of convergence**: the larger it is, the faster the gap closes (half-life $\approx \ln 2 / \lambda$). Two economies with the *same* $y^{*}$ but different $y$ both obey this with the same $\lambda$, so the lower-$y$ one grows faster and catches up. Two economies with *different* $y^{*}$ each shrink the gap to their *own* target — the cross-country gap need not close.
+
+</details>
+:::
+
+## What the simulator showed
+
+With both countries sharing parameters, the two output paths chased the *same* dashed steady-state line: the poor country (blue) shot up steeply while the rich one (green) barely moved, and the gap between them narrowed period by period — absolute convergence in action, with the poorer economy posting the higher growth rate. Flip on the conditional-convergence toggle and Country B aims at a *higher* dashed target: now both still "converge," each to its own $y^{*}$, but the poor country never catches the rich one — the gap can even stay constant or widen. Same model, opposite headline, depending entirely on whether the steady states match.
+
+## Common confusions
+
+::: {.im-confusion}
+**"All poor countries should be catching up to rich ones."** No — that is *absolute* convergence, which the Solow model predicts only when economies share the same steady-state determinants ($s$, $n$, $\delta$, $\alpha$, technology). In world data those parameters differ wildly, so raw growth-vs-initial-income shows little catch-up. The model predicts only *conditional* convergence: catch-up among countries headed for the *same* steady state.
+:::
+
+::: {.im-confusion}
+**"Convergence means every country ends up equally rich."** Only if they share parameters. Convergence means each economy approaches *its own* steady state. A low-saving country converges to a low $y^{*}$; a high-saving country converges to a high $y^{*}$. Both have "converged," yet they are permanently unequal.
+:::
+
+## Self-check
+
+<div class="im-mcq">
+<div class="im-q-label">Q1 · concept</div>
+
+Country A is poor with savings rate $s=0.1$; Country B is rich with $s=0.3$. All other parameters are identical. The Solow model predicts:
+
+<details><summary>a) A grows faster and catches up to B (absolute convergence)</summary>
+No — A and B have *different* steady states because their saving rates differ. A heads for a low $y^{*}$, so it need not catch B at all.
+</details>
+<details><summary>b) Each converges to its own steady state; A need not catch B (conditional convergence)</summary>
+✅ Correct. With different $s$, the two have different $k^{*}$. Each converges to its *own* target, so the income gap between them need not close. This is conditional convergence.
+</details>
+<details><summary>c) Neither converges because their parameters differ</summary>
+No — different parameters don't prevent convergence; they just give each country a *different* steady state to converge toward.
+</details>
+</div>
+
+<div class="im-mcq">
+<div class="im-q-label">Q2 · simulator challenge</div>
+
+Set **s = 0.20, δ = 0.05, n = 0, α = 0.33** (the same for both countries). What is the shared steady-state capital $k^{*}$, and roughly $y^{*}$?
+
+<details><summary>Reveal answer</summary>
+$k^{*} = \bigl(s/(\delta+n)\bigr)^{1/(1-\alpha)} = (0.20/0.05)^{1/0.67} = 4^{1.49} \approx 7.9$, and $y^{*} = (k^{*})^{0.33} \approx 7.9^{0.33} \approx 1.97$. Both dashed lines sit on top of each other at **y\* ≈ 1.97** — absolute convergence, so A catches up to B.
+</details>
+</div>
+
+{{< include ../_includes/generated/convergence_hypo-related.md >}}

--- a/content/convergence_hypo.qmd
+++ b/content/convergence_hypo.qmd
@@ -15,7 +15,7 @@ subtitle: "When do poor countries catch up to rich ones — and when do they not
 - Explain the empirical signature of convergence: a *negative* relationship between initial income and subsequent growth, holding steady-state determinants constant.
 - Predict, for two economies, whether and how fast the income gap between them will shrink.
 
-## 🚀 Try it first
+## Explore the model
 
 ::: {.im-sim-hero}
 ::: {.im-sim-label}
@@ -142,7 +142,7 @@ Country A is poor with savings rate $s=0.1$; Country B is rich with $s=0.3$. All
 No — A and B have *different* steady states because their saving rates differ. A heads for a low $y^{*}$, so it need not catch B at all.
 </details>
 <details><summary>b) Each converges to its own steady state; A need not catch B (conditional convergence)</summary>
-✅ Correct. With different $s$, the two have different $k^{*}$. Each converges to its *own* target, so the income gap between them need not close. This is conditional convergence.
+**Correct**. With different $s$, the two have different $k^{*}$. Each converges to its *own* target, so the income gap between them need not close. This is conditional convergence.
 </details>
 <details><summary>c) Neither converges because their parameters differ</summary>
 No — different parameters don't prevent convergence; they just give each country a *different* steady state to converge toward.

--- a/content/foundations_growth.qmd
+++ b/content/foundations_growth.qmd
@@ -15,7 +15,7 @@ subtitle: "How rich you are and how fast you're getting richer are two different
 - Read a time path and identify which of two economies is richer vs. which is catching up.
 - Connect this distinction to the convergence pattern you'll see in later chapters.
 
-## 🚀 Try it first
+## Explore the model
 
 ::: {.im-sim-hero}
 ::: {.im-sim-label}
@@ -99,7 +99,7 @@ Country X has GDP per capita of \$40,000 growing at 1%. Country Y has \$5,000 gr
 No — Y's far higher growth rate means it closes the gap and eventually overtakes X.
 </details>
 <details><summary>b) Y is catching up and will overtake X given enough time</summary>
-✅ Correct. A higher growth rate compounds; the level head-start is finite, so Y eventually passes X.
+**Correct**. A higher growth rate compounds; the level head-start is finite, so Y eventually passes X.
 </details>
 <details><summary>c) They grow at the same speed since growth is just level times rate</summary>
 No — growth *rate* is independent of the level. Y's 7% beats X's 1% regardless of who is richer now.

--- a/content/humancapital.qmd
+++ b/content/humancapital.qmd
@@ -1,0 +1,145 @@
+---
+title: "Human Capital"
+subtitle: "A second engine of accumulation — augmenting Solow with the stock of skills and education"
+---
+
+{{< include ../_includes/generated/humancapital-prereqs.md >}}
+
+::: {.im-tldr}
+**TL;DR** — The augmented Solow model (Mankiw–Romer–Weil) treats education and skills as an *accumulable stock* $h$, just like physical capital $k$. Output now leans on two reproducible factors, $y = k^{\alpha}h^{\beta}$. Raising the human-capital saving rate $s_h$ permanently lifts steady-state income, and because income depends on *two* things you can build up, the response of income to saving is amplified relative to plain Solow. Long-run *growth* is still zero without exogenous technology — what changes is the *level*.
+:::
+
+## You'll be able to
+
+- Trace the joint paths of physical capital $k$, human capital $h$, and output $y$ as they converge to their steady states.
+- Explain why human capital acts as a *second reproducible factor* rather than as raw labor.
+- Predict how a change in the human-capital saving rate $s_h$ shifts steady-state income — and why that response is larger than in the one-factor model.
+
+## 🚀 Try it first
+
+::: {.im-sim-hero}
+::: {.im-sim-label}
+Change the two saving rates and watch both capital stocks climb toward their targets
+:::
+
+```{ojs}
+//| echo: false
+viewof skHc    = Inputs.range([0.05, 0.5], {value: 0.25, step: 0.01, label: "physical saving s_k"})
+viewof shHc    = Inputs.range([0.05, 0.5], {value: 0.25, step: 0.01, label: "human saving s_h"})
+viewof alphaHc = Inputs.range([0.15, 0.45], {value: 0.33, step: 0.01, label: "physical share α"})
+viewof betaHc  = Inputs.range([0.15, 0.45], {value: 0.33, step: 0.01, label: "human share β"})
+viewof deltaHc = Inputs.range([0.01, 0.2], {value: 0.05, step: 0.01, label: "depreciation δ"})
+viewof k0Hc    = Inputs.range([0.1, 20], {value: 1.0, step: 0.1, label: "initial physical k₀"})
+viewof h0Hc    = Inputs.range([0.1, 20], {value: 1.0, step: 0.1, label: "initial human h₀"})
+viewof THc     = Inputs.range([20, 200], {value: 100, step: 5, label: "time horizon"})
+
+denomHc = Math.max(1 - alphaHc - betaHc, 0.001)
+
+kstarHc = Math.pow(Math.pow(skHc, 1 - betaHc) * Math.pow(shHc, betaHc) / deltaHc, 1 / denomHc)
+hstarHc = Math.pow(Math.pow(skHc, alphaHc) * Math.pow(shHc, 1 - alphaHc) / deltaHc, 1 / denomHc)
+ystarHc = Math.pow(kstarHc, alphaHc) * Math.pow(hstarHc, betaHc)
+
+pathHc = {
+  const T = THc, rows = [];
+  let k = k0Hc, h = h0Hc;
+  for (let t = 0; t < T; t++) {
+    const y = Math.pow(k, alphaHc) * Math.pow(h, betaHc);
+    rows.push({t, k, h, y});
+    k = Math.max(k + skHc * y - deltaHc * k, 1e-9);
+    h = Math.max(h + shHc * y - deltaHc * h, 1e-9);
+  }
+  return rows;
+}
+
+Plot.plot({
+  marginLeft: 50,
+  x: {label: "time →"},
+  y: {label: "level", grid: true},
+  marks: [
+    Plot.ruleY([kstarHc], {stroke: "var(--im-accent)", strokeDasharray: "3 3", opacity: 0.5}),
+    Plot.ruleY([hstarHc], {stroke: "var(--im-danger)", strokeDasharray: "3 3", opacity: 0.5}),
+    Plot.ruleY([ystarHc], {stroke: "var(--im-sim)", strokeDasharray: "3 3", opacity: 0.5}),
+    Plot.line(pathHc, {x: "t", y: "k", stroke: "var(--im-accent)", strokeWidth: 2.5}),
+    Plot.line(pathHc, {x: "t", y: "h", stroke: "var(--im-danger)", strokeWidth: 2.5}),
+    Plot.line(pathHc, {x: "t", y: "y", stroke: "var(--im-sim)", strokeWidth: 2.5}),
+    Plot.text([{t: THc * 0.5, y: kstarHc}], {text: d => `k* = ${kstarHc.toFixed(1)}`, dy: -8, fill: "var(--im-accent)"}),
+    Plot.text([{t: THc * 0.5, y: hstarHc}], {text: d => `h* = ${hstarHc.toFixed(1)}`, dy: -8, fill: "var(--im-danger)"}),
+    Plot.text([{t: THc * 0.5, y: ystarHc}], {text: d => `y* = ${ystarHc.toFixed(1)}`, dy: -8, fill: "var(--im-sim)"})
+  ]
+})
+```
+
+```{ojs}
+//| echo: false
+md`**Steady-state targets** — physical capital $k^{*}$ = **${kstarHc.toFixed(2)}**, human capital $h^{*}$ = **${hstarHc.toFixed(2)}**, output per worker $y^{*}$ = **${ystarHc.toFixed(2)}**. ${(alphaHc + betaHc >= 0.97) ? "⚠️ With α + β near 1 the model approaches endogenous-growth-like sensitivity: tiny changes in saving move the steady state enormously." : ""}`
+```
+
+The blue line is physical capital, the red line is human capital, and the green line is output — each converging to its dashed target. Try nudging $s_h$ up by a little and watch *all three* lines lift: more schooling feeds back into more output, which finances more of *both* stocks.
+:::
+
+## Core intuition
+
+Plain Solow has one thing you can build up: physical capital. The augmented model adds a second — [human capital]{.im-glossary-term}, the stock of skills and education embodied in workers. Both are *reproducible*: each is accumulated by saving a slice of current output and erodes through depreciation. Output uses both, $y = k^{\alpha}h^{\beta}$, with $\alpha + \beta < 1$ so each factor still faces [diminishing returns]{.im-glossary-term}.
+
+The two stocks reinforce each other. More physical capital raises output, which finances more investment in *both* $k$ and $h$; more human capital does the same. The economy settles at a [steady state]{.im-glossary-term} where each stock's investment just covers its own depreciation. Because income now rests on two factors you can grow, raising a saving rate has a *larger* level effect than in one-factor Solow — and as $\alpha + \beta \to 1$, that effect grows without bound, approaching the knife-edge of endogenous growth.
+
+::: {.im-math-toggle}
+<details>
+<summary>Show the math</summary>
+
+Output per worker depends on both reproducible stocks:
+$$y = k^{\alpha}\,h^{\beta}, \qquad \alpha + \beta < 1.$$
+Each stock accumulates from its own saving rate and shares the depreciation rate $\delta$:
+$$k_{t+1} = k_t + s_k\,y_t - \delta k_t, \qquad h_{t+1} = h_t + s_h\,y_t - \delta h_t.$$
+Setting both changes to zero and solving simultaneously gives the steady state
+$$k^{*} = \left(\frac{s_k^{\,1-\beta}\, s_h^{\,\beta}}{\delta}\right)^{\frac{1}{1-\alpha-\beta}}, \qquad
+h^{*} = \left(\frac{s_k^{\,\alpha}\, s_h^{\,1-\alpha}}{\delta}\right)^{\frac{1}{1-\alpha-\beta}},$$
+$$y^{*} = (k^{*})^{\alpha}(h^{*})^{\beta}.$$
+The exponent $\tfrac{1}{1-\alpha-\beta}$ is what amplifies the response of income to saving: as $\alpha+\beta \to 1$ it explodes, so the level effect of saving becomes arbitrarily large.
+
+</details>
+:::
+
+## What the simulator showed
+
+Starting from small stocks, all three lines climbed steeply and then bent over toward their dashed targets — the familiar curved convergence, but now with *two* capital lines moving in tandem. Pushing $s_h$ up lifted $h^{*}$ directly and dragged $k^{*}$ and $y^{*}$ up with it, because the extra human capital raises output, which finances more physical investment too. The lift in $y^{*}$ from a given change in saving was bigger than plain Solow would predict — the two-factor structure amplifies it. And cranking $\alpha + \beta$ toward 1 made the steady state shoot up dramatically, the simulator's window into endogenous-growth-like sensitivity.
+
+## Common confusions
+
+::: {.im-confusion}
+**"Human capital is just labor."** No — raw labor $L$ is a fixed (or exogenously growing) input, while human capital $h$ is an *accumulable stock* built by investing output, exactly like physical capital. That is precisely why it acts as a *second engine* of accumulation rather than a background factor.
+:::
+
+::: {.im-confusion}
+**"Adding human capital changes the long-run growth rate."** No — just like plain Solow, the long-run growth of output per worker is still *zero* without exogenous technological progress. Once both stocks reach their steady states, $y$ stops growing. Human capital raises the steady-state *level* of income, not its long-run growth rate.
+:::
+
+## Self-check
+
+<div class="im-mcq">
+<div class="im-q-label">Q1 · concept</div>
+
+Two countries share identical $s_k$, $\delta$, $\alpha$, $\beta$, and technology, but one has a higher human-capital saving rate $s_h$. In the long run, the high-$s_h$ country has:
+
+<details><summary>a) A higher steady-state level of income, but the same long-run growth rate</summary>
+✅ Correct. A higher $s_h$ raises $h^{*}$ (and pulls up $k^{*}$ and $y^{*}$ with it), so income is permanently *higher*. But once stocks settle, growth of $y$ is zero in both countries — like Solow, saving sets the level, not the long-run growth rate.
+</details>
+<details><summary>b) A permanently higher growth rate of output per worker</summary>
+No — without exogenous technological progress, long-run growth of $y$ is zero regardless of $s_h$. Saving changes the level, not the perpetual growth rate.
+</details>
+<details><summary>c) The same steady-state income, since human capital is just relabeled labor</summary>
+No — human capital is an accumulable stock, not raw labor. A higher $s_h$ genuinely raises $h^{*}$ and therefore $y^{*}$.
+</details>
+</div>
+
+<div class="im-mcq">
+<div class="im-q-label">Q2 · simulator challenge</div>
+
+Set **s_k = s_h = 0.25, δ = 0.05, α = β = 1/3**. What are the steady-state stocks $k^{*}$ and $h^{*}$, and steady-state output $y^{*}$?
+
+<details><summary>Reveal answer</summary>
+With $s_k = s_h = s$ and $\alpha = \beta$, the formulas collapse to $k^{*} = h^{*} = \left(s/\delta\right)^{1/(1-\alpha-\beta)} = (0.25/0.05)^{1/(1/3)} = 5^{3} = \mathbf{125}$. Then $y^{*} = (125)^{1/3}(125)^{1/3} = 125^{2/3} \approx \mathbf{25}$. The dashed $k^{*}$ and $h^{*}$ lines sit at **125** and the $y^{*}$ line near **25**.
+</details>
+</div>
+
+{{< include ../_includes/generated/humancapital-related.md >}}

--- a/content/humancapital.qmd
+++ b/content/humancapital.qmd
@@ -15,7 +15,7 @@ subtitle: "A second engine of accumulation — augmenting Solow with the stock o
 - Explain why human capital acts as a *second reproducible factor* rather than as raw labor.
 - Predict how a change in the human-capital saving rate $s_h$ shifts steady-state income — and why that response is larger than in the one-factor model.
 
-## 🚀 Try it first
+## Explore the model
 
 ::: {.im-sim-hero}
 ::: {.im-sim-label}
@@ -122,7 +122,7 @@ Starting from small stocks, all three lines climbed steeply and then bent over t
 Two countries share identical $s_k$, $\delta$, $\alpha$, $\beta$, and technology, but one has a higher human-capital saving rate $s_h$. In the long run, the high-$s_h$ country has:
 
 <details><summary>a) A higher steady-state level of income, but the same long-run growth rate</summary>
-✅ Correct. A higher $s_h$ raises $h^{*}$ (and pulls up $k^{*}$ and $y^{*}$ with it), so income is permanently *higher*. But once stocks settle, growth of $y$ is zero in both countries — like Solow, saving sets the level, not the long-run growth rate.
+**Correct**. A higher $s_h$ raises $h^{*}$ (and pulls up $k^{*}$ and $y^{*}$ with it), so income is permanently *higher*. But once stocks settle, growth of $y$ is zero in both countries — like Solow, saving sets the level, not the long-run growth rate.
 </details>
 <details><summary>b) A permanently higher growth rate of output per worker</summary>
 No — without exogenous technological progress, long-run growth of $y$ is zero regardless of $s_h$. Saving changes the level, not the perpetual growth rate.

--- a/content/solow_intro.qmd
+++ b/content/solow_intro.qmd
@@ -15,7 +15,7 @@ subtitle: "Why saving more makes you richer, not faster-growing"
 - Explain why the *level* of income and the *growth rate* of income are different things.
 - Read empirical convergence patterns through the model's lens.
 
-## 🚀 Try it first
+## Explore the model
 
 ::: {.im-sim-hero}
 ::: {.im-sim-label}
@@ -103,7 +103,7 @@ A country permanently doubles its savings rate. In the long run, which is true?
 No — long-run growth is set by `g`, not `s`. Growth rises only during the transition.
 </details>
 <details><summary>b) Its steady-state capital per worker rises</summary>
-✅ Correct. `k* = (s/(n+g+δ))^{1/(1−α)}` rises with `s` — a higher *level*, reached via temporarily faster growth.
+**Correct**. `k* = (s/(n+g+δ))^{1/(1−α)}` rises with `s` — a higher *level*, reached via temporarily faster growth.
 </details>
 <details><summary>c) Nothing changes</summary>
 No — the level changes even though the long-run growth rate doesn't.

--- a/content/solow_pop&_tech_growth.qmd
+++ b/content/solow_pop&_tech_growth.qmd
@@ -1,0 +1,137 @@
+---
+title: "Population & Technology Growth"
+subtitle: "Why only technological progress — not saving harder or breeding faster — raises living standards forever"
+---
+
+{{< include ../_includes/generated/solow_pop&_tech_growth-prereqs.md >}}
+
+::: {.im-tldr}
+**TL;DR** — Measure everything *per effective worker* ($\tilde k = K/(AL)$) and the Solow economy settles to a constant steady state $\tilde k^{*}$, just like the basic model. But because each worker now commands more technology over time, output *per worker* keeps rising at the tech-growth rate $g$ forever, and *aggregate* output grows at $n+g$. Faster population growth $n$ doesn't enrich anyone — it *dilutes* capital and lowers $\tilde k^{*}$.
+:::
+
+## You'll be able to
+
+- Rescale the Solow model into per-effective-worker terms and find $\tilde k^{*}$ and $\tilde y^{*}$.
+- Explain why per-worker living standards grow at $g$ while aggregate output grows at $n+g$.
+- Predict that faster population growth *lowers* steady-state capital per effective worker.
+
+## 🚀 Try it first
+
+::: {.im-sim-hero}
+::: {.im-sim-label}
+Crank up population growth n and watch the steady state fall — then add tech growth g
+:::
+
+```{ojs}
+//| echo: false
+viewof sSpt      = Inputs.range([0.05, 0.9], {value: 0.30, step: 0.01, label: "savings rate s"})
+viewof deltaSpt  = Inputs.range([0.01, 0.2], {value: 0.05, step: 0.005, label: "depreciation δ"})
+viewof alphaSpt  = Inputs.range([0.1, 0.7], {value: 0.30, step: 0.05, label: "capital share α"})
+viewof nSpt      = Inputs.range([0.0, 0.05], {value: 0.01, step: 0.005, label: "population growth n"})
+viewof gSpt      = Inputs.range([0.0, 0.05], {value: 0.02, step: 0.005, label: "tech growth g"})
+viewof k0Spt     = Inputs.range([0.1, 10], {value: 1.0, step: 0.1, label: "initial k̃₀"})
+viewof TSpt      = Inputs.range([10, 100], {value: 50, step: 5, label: "time horizon"})
+
+kstarSpt = Math.pow(sSpt / (deltaSpt + nSpt + gSpt), 1 / (1 - alphaSpt))
+ystarSpt = Math.pow(kstarSpt, alphaSpt)
+
+pathSpt = {
+  const T = TSpt, rows = [];
+  let k = k0Spt;
+  for (let t = 0; t < T; t++) {
+    const y = Math.pow(k, alphaSpt);
+    rows.push({t, k, y});
+    k = k + sSpt * y - (deltaSpt + nSpt + gSpt) * k;
+  }
+  return rows;
+}
+
+Plot.plot({
+  marginLeft: 50,
+  x: {label: "time →"},
+  y: {label: "per effective worker", grid: true},
+  marks: [
+    Plot.ruleY([kstarSpt], {stroke: "var(--im-accent)", strokeDasharray: "3 3", opacity: 0.5}),
+    Plot.ruleY([ystarSpt], {stroke: "var(--im-sim)", strokeDasharray: "3 3", opacity: 0.5}),
+    Plot.line(pathSpt, {x: "t", y: "k", stroke: "var(--im-accent)", strokeWidth: 2.5}),
+    Plot.line(pathSpt, {x: "t", y: "y", stroke: "var(--im-sim)", strokeWidth: 2.5}),
+    Plot.text([{t: TSpt * 0.5, y: kstarSpt}], {text: d => `k̃* = ${kstarSpt.toFixed(2)}`, dy: -8, fill: "var(--im-accent)"}),
+    Plot.text([{t: TSpt * 0.5, y: ystarSpt}], {text: d => `ỹ* = ${ystarSpt.toFixed(2)}`, dy: -8, fill: "var(--im-sim)"})
+  ]
+})
+```
+
+```{ojs}
+//| echo: false
+md`**Steady state (per effective worker):** $\tilde k^{*} =$ **${kstarSpt.toFixed(3)}**,  $\tilde y^{*} =$ **${ystarSpt.toFixed(3)}**. In the long run, output **per worker** grows at $g =$ **${(gSpt*100).toFixed(1)}%** per period, while **aggregate** output grows at $n+g =$ **${((nSpt+gSpt)*100).toFixed(1)}%**.`
+```
+
+The blue line is capital per effective worker $\tilde k$, green is output per effective worker $\tilde y$, and the dashed lines are their steady-state targets. Slide $n$ up and the dashed targets drop — more mouths to equip means less capital each. Slide $g$ up and the targets *also* drop, yet the readout reminds you that per-worker income is now climbing at $g$ forever.
+:::
+
+## Core intuition
+
+Once labor grows at rate $n$ and technology at rate $g$, raw capital per worker is a moving target. The trick is to rescale by *effective* labor $AL$: count capital and output **per effective worker**, $\tilde k = K/(AL)$ and $\tilde y = \tilde k^{\alpha}$. In these units the model looks exactly like the basic Solow model, with one change: capital must now be spread across a workforce of effective labor that is itself expanding at $n+g$.
+
+So the [break-even investment]{.im-glossary-term} needed just to hold $\tilde k$ steady is no longer $\delta\tilde k$ but $(\delta + n + g)\tilde k$ — you replace worn-out capital *and* equip the new effective workers. Investment $s\tilde k^{\alpha}$ runs into [diminishing returns]{.im-glossary-term}, so the two curves cross at a single [steady state]{.im-glossary-term} $\tilde k^{*}$, and the economy [converges]{.im-glossary-term} to it.
+
+Here's the payoff. At $\tilde k^{*}$, *effective*-worker variables are flat. But $y = A\tilde y^{*}$, and $A$ itself grows at $g$ — so income **per worker** rises at $g$ forever. Aggregate output $Y = AL\tilde y^{*}$ grows at $n+g$. Faster population growth $n$ appears only in the denominator $(\delta+n+g)$: it *lowers* $\tilde k^{*}$. Only $g$ delivers sustained gains in living standards.
+
+::: {.im-math-toggle}
+<details>
+<summary>Show the math</summary>
+
+In per-effective-worker terms the law of motion is
+$$\tilde k_{t+1} = \tilde k_t + s\,\tilde k_t^{\alpha} - (\delta + n + g)\,\tilde k_t.$$
+Setting $\tilde k_{t+1} = \tilde k_t$ (so $s\tilde k^{\alpha} = (\delta+n+g)\tilde k$) gives the steady state
+$$\tilde k^{*} = \left(\frac{s}{\delta + n + g}\right)^{\frac{1}{1-\alpha}}, \qquad \tilde y^{*} = (\tilde k^{*})^{\alpha}.$$
+Because $n$ and $g$ sit in the denominator, raising either one *lowers* $\tilde k^{*}$. Yet since $y = A\tilde y$ and $\dot A / A = g$,
+$$\frac{\dot y}{y} = g, \qquad \frac{\dot Y}{Y} = n + g.$$
+Living standards (output per worker) grow at $g$; aggregate output grows at $n+g$.
+
+</details>
+:::
+
+## What the simulator showed
+
+From any starting $\tilde k_0$, both lines bent toward the dashed targets and flattened — convergence in per-effective-worker terms, exactly like the basic model. Pushing $n$ up slid the dashed targets *down*: extra population dilutes the capital stock. Pushing $g$ up *also* lowered the dashed $\tilde k^{*}$, but the readout showed per-worker income now growing at the higher $g$ forever and aggregate output at $n+g$. The steady state is about *effective*-worker ratios; real living standards ride on top of it via $A$.
+
+## Common confusions
+
+::: {.im-confusion}
+**"Faster population growth makes a country richer."** No — $n$ enters the break-even term $(\delta+n+g)\tilde k$, so more population growth *dilutes* capital and *lowers* $\tilde k^{*}$ and $\tilde y^{*}$. It raises aggregate output growth (to $n+g$) but not income *per worker*.
+:::
+
+::: {.im-confusion}
+**"Without technology growth, living standards still rise forever."** No — with $g = 0$, per-effective-worker and per-worker variables coincide and are *constant* at the steady state. Saving more shifts you to a higher plateau once, but only $g > 0$ delivers *sustained* growth in living standards.
+:::
+
+## Self-check
+
+<div class="im-mcq">
+<div class="im-q-label">Q1 · concept</div>
+
+In the steady state, at what rate does output **per worker** ($y = A\tilde y$) grow?
+
+<details><summary>a) g (the technology growth rate)</summary>
+✅ Correct. Per-effective-worker output $\tilde y$ is constant at steady state, so $y = A\tilde y$ grows at the rate of $A$, which is $g$. Only technological progress raises living standards in the long run.
+</details>
+<details><summary>b) n + g</summary>
+No — that's the growth rate of *aggregate* output $Y = AL\tilde y$, which also picks up labor-force growth $n$. Per-*worker* output grows only at $g$.
+</details>
+<details><summary>c) zero — the economy is at a steady state</summary>
+No — only the *per-effective-worker* variables are constant. Per-worker income still rises with $A$ at rate $g$.
+</details>
+</div>
+
+<div class="im-mcq">
+<div class="im-q-label">Q2 · simulator challenge</div>
+
+Set **s = 0.20, δ = 0.05, n = 0.01, g = 0.02, α = 0.33**. What is the steady-state capital per effective worker $\tilde k^{*}$?
+
+<details><summary>Reveal answer</summary>
+$\tilde k^{*} = \left(\dfrac{s}{\delta+n+g}\right)^{1/(1-\alpha)} = \left(\dfrac{0.20}{0.08}\right)^{1/0.67} = 2.5^{1.49} \approx 3.9$. The dashed blue line should sit near **k̃* ≈ 3.9** (and $\tilde y^{*} \approx 1.57$).
+</details>
+</div>
+
+{{< include ../_includes/generated/solow_pop&_tech_growth-related.md >}}

--- a/content/solow_pop&_tech_growth.qmd
+++ b/content/solow_pop&_tech_growth.qmd
@@ -15,7 +15,7 @@ subtitle: "Why only technological progress — not saving harder or breeding fas
 - Explain why per-worker living standards grow at $g$ while aggregate output grows at $n+g$.
 - Predict that faster population growth *lowers* steady-state capital per effective worker.
 
-## 🚀 Try it first
+## Explore the model
 
 ::: {.im-sim-hero}
 ::: {.im-sim-label}
@@ -114,7 +114,7 @@ From any starting $\tilde k_0$, both lines bent toward the dashed targets and fl
 In the steady state, at what rate does output **per worker** ($y = A\tilde y$) grow?
 
 <details><summary>a) g (the technology growth rate)</summary>
-✅ Correct. Per-effective-worker output $\tilde y$ is constant at steady state, so $y = A\tilde y$ grows at the rate of $A$, which is $g$. Only technological progress raises living standards in the long run.
+**Correct**. Per-effective-worker output $\tilde y$ is constant at steady state, so $y = A\tilde y$ grows at the rate of $A$, which is $g$. Only technological progress raises living standards in the long run.
 </details>
 <details><summary>b) n + g</summary>
 No — that's the growth rate of *aggregate* output $Y = AL\tilde y$, which also picks up labor-force growth $n$. Per-*worker* output grows only at $g$.

--- a/content/solow_transition.qmd
+++ b/content/solow_transition.qmd
@@ -15,7 +15,7 @@ subtitle: "How an economy actually travels to its steady state — fast at first
 - Explain why convergence is fast far from $k^{*}$ and slow near it.
 - Predict what happens when an economy starts *above* its steady state.
 
-## 🚀 Try it first
+## Explore the model
 
 ::: {.im-sim-hero}
 ::: {.im-sim-label}
@@ -106,7 +106,7 @@ Starting from a tiny $k_0$, both lines shot up steeply, then bent over and level
 Two economies have identical $s$, $\delta$, $\alpha$, $A$ but different starting capital: one far below $k^{*}$, one just below it. Which grows faster initially?
 
 <details><summary>a) The one far below k*</summary>
-✅ Correct. The further below $k^{*}$, the larger the gap between investment and depreciation, so the faster capital grows. This is the convergence mechanism.
+**Correct**. The further below $k^{*}$, the larger the gap between investment and depreciation, so the faster capital grows. This is the convergence mechanism.
 </details>
 <details><summary>b) The one just below k*</summary>
 No — near $k^{*}$ investment and depreciation nearly balance, so growth is slow.

--- a/content/two_period_consumption.qmd
+++ b/content/two_period_consumption.qmd
@@ -15,7 +15,7 @@ subtitle: "Consumption smoothing, the Euler equation, and why interest rates til
 - Explain why the agent is a *saver* (c₁ < y₁) vs a *borrower* (c₁ > y₁) depending on parameters.
 - Decompose an interest-rate change into a substitution effect and an income effect, and predict which dominates for savers vs borrowers.
 
-## 🚀 Try it first
+## Explore the model
 
 ::: {.im-sim-hero}
 ::: {.im-sim-label}
@@ -129,7 +129,7 @@ Suppose the agent is currently a **lender** (c₁ < y₁). The real interest rat
 Not necessarily. The substitution effect does push toward saving more (lower c₁), but the income effect — the lender earns more on existing savings — pushes c₁ up. The net direction is ambiguous.
 </details>
 <details><summary>b) c₁ is ambiguous — substitution and income effects offset each other</summary>
-✅ Correct. For a lender, a higher r creates a substitution effect (future consumption cheaper → save more → lower c₁) and a positive income effect (higher return on savings → richer → higher c₁). Standard theory does not pin the sign.
+**Correct**. For a lender, a higher r creates a substitution effect (future consumption cheaper → save more → lower c₁) and a positive income effect (higher return on savings → richer → higher c₁). Standard theory does not pin the sign.
 </details>
 <details><summary>c) c₁ must rise — the income effect always dominates for lenders</summary>
 No — the income effect works in that direction, but it need not dominate the substitution effect.

--- a/index.qmd
+++ b/index.qmd
@@ -1,105 +1,73 @@
 ---
-pagetitle: "Intermediate Macroeconomics — Interactive Dashboard"
+title: "Intermediate Macroeconomics"
+subtitle: "Interactive models for self-study"
+pagetitle: "Intermediate Macroeconomics"
 toc: false
-page-layout: full
 ---
 
-```{=html}
-<section class="im-hero">
-  <span class="im-hero-eyebrow">UVA · Intermediate Macroeconomics</span>
-  <div class="im-hero-title">Macro models you can <span class="grad">actually play with.</span></div>
-  <p class="im-hero-sub">
-    A self-study dashboard of working macroeconomic models. Every chapter pairs clean,
-    derivable math with a <strong>live in-browser simulator</strong> and self-check questions —
-    so you can build intuition by moving the sliders, not just reading the algebra.
-  </p>
+This site is an interactive companion to an intermediate macroeconomics course.
+Each chapter develops one model — its assumptions, key equations, and intuition —
+and pairs it with a simulator you can adjust directly in your browser, alongside
+worked explanations and self-check questions. It is built for self-study: read
+through a model, then change its parameters and watch how the results respond.
 
-  <div class="im-hero-cta">
-    <a class="im-btn im-btn-primary" href="content/solow_intro.html">Open the Solow simulator →</a>
-    <a class="im-btn im-btn-ghost" href="content/Preliminaries.html">Start with the math primer</a>
-  </div>
+The chapters are organized into five tracks. If you are starting fresh, begin
+with **Foundations**; otherwise, jump to whatever you are working on. Key terms
+appear as hover definitions throughout and are collected in the
+[Glossary](_glossary.qmd).
 
-  <div class="im-stats">
-    <div class="im-stat"><div class="im-stat-num">30+</div><div class="im-stat-label">Models</div></div>
-    <div class="im-stat"><div class="im-stat-num">5</div><div class="im-stat-label">Tracks</div></div>
-    <div class="im-stat"><div class="im-stat-num">3</div><div class="im-stat-label">Live simulators</div></div>
-    <div class="im-stat"><div class="im-stat-num">100%</div><div class="im-stat-label">Runs in-browser</div></div>
-  </div>
-</section>
+## Foundations
 
-<div class="im-section-label">Featured · interactive</div>
-<div class="im-track-grid">
+*The mathematical toolkit the rest of the course assumes.*
 
-  <a class="im-track-card" href="content/solow_intro.html">
-    <div class="im-track-icon">🌱</div>
-    <span class="im-live-badge">Live simulator</span>
-    <h3>The Solow Growth Model</h3>
-    <p>Move savings, population growth, and depreciation — watch the economy converge to its steady state in real time.</p>
-    <div class="im-track-meta"><span>Growth track</span><span class="im-track-go">Explore →</span></div>
-  </a>
+- [Mathematical Preliminaries](content/Preliminaries.ipynb) — growth rates, compounding, and the log approximation used throughout.
 
-  <a class="im-track-card" href="content/two_period_consumption.html">
-    <div class="im-track-icon">⏳</div>
-    <span class="im-live-badge">Live simulator</span>
-    <h3>Two-Period Consumption</h3>
-    <p>Shift income and interest rates across the budget line and indifference curves to see borrowing vs. saving emerge.</p>
-    <div class="im-track-meta"><span>Intertemporal track</span><span class="im-track-go">Explore →</span></div>
-  </a>
+## Measurement & National Accounts
 
-  <a class="im-track-card" href="content/adassim.html">
-    <div class="im-track-icon">📈</div>
-    <span class="im-live-badge">Live simulator</span>
-    <h3>Dynamic AD–AS</h3>
-    <p>Tune the Taylor rule and shock the economy — trace inflation, the output gap, and the path back to equilibrium.</p>
-    <div class="im-track-meta"><span>Business cycles track</span><span class="im-track-go">Explore →</span></div>
-  </a>
+*How raw economic activity becomes the numbers we analyze.*
 
-</div>
+- [Measuring GDP: The Expenditure Approach](content/measuring_gdp.ipynb) — output as the sum of consumption, investment, government, and net exports.
+- [Real vs. Nominal GDP Over Time](content/realvsnom.ipynb) — separating genuine output changes from price changes.
+- [Deflators and Price Indices](content/cash_money.ipynb) — how a price index is built and why we deflate.
+- [Real GDP with Changing Prices](content/two_goods_twoperiods.ipynb) — base-year versus chain-weighted measures of real output.
+- [Comparing GDP Across Countries](content/realgdpacross.ipynb) — purchasing-power-parity adjustments for cross-country comparison.
 
-<div class="im-section-label">Browse by track</div>
-<div class="im-track-grid">
+## Growth & Long-Run Dynamics
 
-  <a class="im-track-card" href="content/Preliminaries.html">
-    <div class="im-track-icon">📐</div>
-    <h3>Foundations</h3>
-    <p>The shared mathematical vocabulary — growth rates, the log approximation, and the tools every later chapter leans on.</p>
-    <div class="im-track-meta"><span>1 chapter</span><span class="im-track-go">Start here →</span></div>
-  </a>
+*What makes economies rich over the long run, from Solow to endogenous growth.*
 
-  <a class="im-track-card" href="content/measuring_gdp.html">
-    <div class="im-track-icon">📊</div>
-    <h3>Measurement &amp; National Accounts</h3>
-    <p>GDP, real vs. nominal, price indices, and comparing output across countries with PPP.</p>
-    <div class="im-track-meta"><span>5 chapters</span><span class="im-track-go">Explore →</span></div>
-  </a>
+- [Levels vs. Growth Rates](content/foundations_growth.qmd) — why how rich a country is and how fast it grows are distinct.
+- [Cobb–Douglas Production](content/cobb_d_prod.qmd) — output from capital and labor, diminishing returns, and factor shares.
+- [The Solow Growth Model](content/solow_intro.qmd) — saving, depreciation, and the steady state.
+- [Solow Transition Dynamics](content/solow_transition.qmd) — the path an economy travels toward its steady state.
+- [Population & Technology Growth](content/solow_pop&_tech_growth.qmd) — Solow with a growing workforce and advancing technology.
+- [Human Capital](content/humancapital.qmd) — adding a second accumulable factor to the Solow framework.
+- [The Convergence Hypothesis](content/convergence_hypo.qmd) — when poorer economies do, and do not, catch up.
+- [Solow Model: Exercises & Case Studies](content/solow_model.ipynb) — applied problems built on the Solow framework.
+- [The Romer Model of Endogenous Growth](content/romer_model.ipynb) — ideas, nonrivalry, and growth driven from within.
+- [Scale Effects in the Romer Model](content/scale_effects.ipynb) — how population size influences the rate of innovation.
+- [The Solow–Romer Hybrid Model](content/hybrid_model.ipynb) — combining capital accumulation with endogenous ideas.
+- [Growth Accounting](content/growth_acc.ipynb) — decomposing output growth into capital, labor, and total factor productivity.
+- [Slowing Growth and Declining TFP](content/slowinggrowth.ipynb) — what a falling rate of technological advance implies.
+- [Robots vs. Labor](content/robots.ipynb) — automation and substitution in a CES production model.
 
-  <a class="im-track-card" href="content/solow_intro.html">
-    <div class="im-track-icon">🌱</div>
-    <h3>Growth &amp; Long-Run Dynamics</h3>
-    <p>Solow, Romer, human capital, growth accounting, convergence, and the economics of automation.</p>
-    <div class="im-track-meta"><span>14 chapters</span><span class="im-track-go">Explore →</span></div>
-  </a>
+## Intertemporal Choice & Labor
 
-  <a class="im-track-card" href="content/two_period_consumption.html">
-    <div class="im-track-icon">⏳</div>
-    <h3>Intertemporal Choice &amp; Labor</h3>
-    <p>Two-period consumption, the labor–leisure trade-off, and Tobin's q theory of investment.</p>
-    <div class="im-track-meta"><span>4 chapters</span><span class="im-track-go">Explore →</span></div>
-  </a>
+*Forward-looking decisions about consumption, labor, and investment.*
 
-  <a class="im-track-card" href="content/adassim.html">
-    <div class="im-track-icon">📉</div>
-    <h3>Business Cycles &amp; Policy Dynamics</h3>
-    <p>The IS curve, dynamic AD–AS, the Lucas island model, and real business cycle simulation.</p>
-    <div class="im-track-meta"><span>7 chapters</span><span class="im-track-go">Explore →</span></div>
-  </a>
+- [The Two-Period Consumption Model](content/two_period_consumption.qmd) — splitting lifetime resources between today and tomorrow.
+- [The Two-Period Model: Extensions](content/two_period_model.ipynb) — a more general treatment of intertemporal choice.
+- [The Labor–Leisure Choice](content/labor_leisure_model.ipynb) — trading consumption against time given the real wage.
+- [Investment and Tobin's q](content/tobin_q_model.ipynb) — when the value of capital justifies new investment.
 
-  <a class="im-track-card" href="_glossary.html">
-    <div class="im-track-icon">📖</div>
-    <h3>Glossary</h3>
-    <p>Every key term, defined in one place — with hover tooltips wired throughout the chapters.</p>
-    <div class="im-track-meta"><span>Reference</span><span class="im-track-go">Open →</span></div>
-  </a>
+## Business Cycles & Policy Dynamics
 
-</div>
-```
+*Short-run fluctuations, monetary policy, and the models that explain them.*
+
+- [The IS Curve](content/is_curve_model.ipynb) — interest rates, demand, and goods-market equilibrium.
+- [Dynamic AD–AS with a Taylor Rule](content/adassim.qmd) — inflation and output dynamics under a policy rule.
+- [AD–AS Shocks and Adjustment](content/dynamicshock.ipynb) — how the economy responds to demand and supply shocks.
+- [AD–AS: Exercises & Case Studies](content/adas_model.ipynb) — applied problems using the AD–AS framework.
+- [The Lucas Island Model](content/lucas_island_model.ipynb) — imperfect information and the source of real fluctuations.
+- [Equilibrium Business Cycles with Persistence](content/equilibrium_model.ipynb) — propagation that stretches shocks over time.
+- [The Real Business Cycle Model](content/rbc_simulation.ipynb) — fluctuations as the efficient response to productivity shocks.

--- a/theme/components.scss
+++ b/theme/components.scss
@@ -191,6 +191,20 @@ code:not(.sourceCode), p code, li code {
   margin: 18px 0; font-size: 1.02rem;
 }
 
+// Fallback notice for legacy ipywidgets models awaiting OJS conversion
+.im-model-pending {
+  background: var(--im-bg-surface);
+  border: 1px solid var(--im-border);
+  border-left: 4px solid var(--im-sim);
+  padding: 14px 18px; border-radius: 0 var(--im-radius-md) var(--im-radius-md) 0;
+  margin: 22px 0; color: var(--im-fg-secondary); font-size: 0.95rem; line-height: 1.55;
+}
+.im-model-pending .im-model-pending-label {
+  display: block; margin-bottom: 4px;
+  font-size: 0.72rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--im-sim);
+}
+
 // Simulator hero — the chapter centerpiece (clean bordered panel)
 .im-sim-hero {
   position: relative;

--- a/theme/widget-fallback.js
+++ b/theme/widget-fallback.js
@@ -1,0 +1,53 @@
+<script>
+// Graceful fallback for legacy ipywidgets models.
+//
+// The static site has no Python kernel, so notebook cells whose output is an
+// `ipywidgets` view (application/vnd.jupyter.widget-view+json) render as an
+// empty box — the code shows but the model never appears. Until each chapter is
+// rebuilt as an in-browser Observable JS simulator, this script hides those
+// dead cells and leaves a single, restrained notice in their place so the page
+// reads as a clean explanation rather than a broken widget.
+(function () {
+  function run() {
+    var views = document.querySelectorAll(
+      'script[type="application/vnd.jupyter.widget-view+json"]'
+    );
+    if (!views.length) return;
+
+    var deadCells = [];
+    var seen = new Set();
+    views.forEach(function (view) {
+      var cell = view.closest("div.cell");
+      if (!cell || seen.has(cell)) return;
+      seen.add(cell);
+      deadCells.push(cell);
+    });
+    if (!deadCells.length) return;
+
+    var notice = document.createElement("div");
+    notice.className = "im-model-pending";
+    var label = document.createElement("span");
+    label.className = "im-model-pending-label";
+    label.textContent = "Interactive model being rebuilt";
+    notice.appendChild(label);
+    notice.appendChild(
+      document.createTextNode(
+        "This chapter's simulator is being upgraded to run live in your " +
+          "browser. The walkthrough below still covers the economics in full."
+      )
+    );
+
+    var first = deadCells[0];
+    first.parentNode.insertBefore(notice, first);
+    deadCells.forEach(function (cell) {
+      cell.style.display = "none";
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", run);
+  } else {
+    run();
+  }
+})();
+</script>

--- a/theme/widget-fallback.js
+++ b/theme/widget-fallback.js
@@ -28,12 +28,12 @@
     notice.className = "im-model-pending";
     var label = document.createElement("span");
     label.className = "im-model-pending-label";
-    label.textContent = "Interactive model being rebuilt";
+    label.textContent = "Interactive simulator in preparation";
     notice.appendChild(label);
     notice.appendChild(
       document.createTextNode(
-        "This chapter's simulator is being upgraded to run live in your " +
-          "browser. The walkthrough below still covers the economics in full."
+        "The model and its intuition are explained in full below. An " +
+          "in-browser interactive version of this chapter is being added."
       )
     );
 
@@ -41,6 +41,14 @@
     first.parentNode.insertBefore(notice, first);
     deadCells.forEach(function (cell) {
       cell.style.display = "none";
+    });
+
+    // This is a legacy notebook page (dead widgets present). Besides the
+    // executed cells (already hidden via echo:false), these chapters also carry
+    // Python snippets embedded in their markdown — implementation detail, not
+    // economics. Hide those too so the page reads as a clean explanation.
+    document.querySelectorAll("div.sourceCode").forEach(function (block) {
+      block.style.display = "none";
     });
   }
 


### PR DESCRIPTION
## Summary
A focused pass to fix rendering and make the site read as a restrained academic resource rather than a marketing page. **Not yet deployed — merging this PR is what makes it live.**

### 1. Rendering fix (legacy notebook chapters)
- Unconverted `.ipynb` chapters store models as **ipywidgets**, which can't run in a static site (no Python kernel). They showed walls of raw code with an empty model box.
- `execute: echo: false` hides executed code by default (still reachable via code-tools).
- `theme/widget-fallback.js` hides dead-widget cells **and** the Python snippets embedded in markdown, and leaves one understated "Interactive simulator in preparation" notice. Pages now read as clean text chapters (intuition + equations) until converted.
- **Note:** the only way to give these pages a *working* model is OJS conversion (22 chapters remain) — there is no static shortcut.

### 2. Landing page → academic table of contents
Replaced the hero tagline, `30+/5/3/100%` stat counters, "live simulator" badges, CTA buttons, and emoji track icons with a short intro + chapters grouped into five tracks with one-line descriptions.

### 3. De-vibecode chapters
- `## 🚀 Try it first` → `## Explore the model`.
- `✅ Correct` → plain bold **Correct** in answer keys.

### 4. Three more Growth chapters converted to OJS
Population & Technology Growth, Human Capital, The Convergence Hypothesis — full v2 template with working in-browser simulators. Originals archived with provenance.

## Test plan
- [x] Full `quarto render` succeeds, no errors
- [x] Landing: no marketing chrome; all 30 chapter links resolve (incl. ampersand filename)
- [x] Converted chapters: working sims, no rocket emoji, plain answer keys
- [x] Unconverted chapters: zero visible code blocks, clean narrative + single notice
- [x] 3 new chapters verified in-browser (plots, sliders, MCQs, reactivity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)